### PR TITLE
Redundant code fix

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -246,51 +246,52 @@ dedications to their spouses/children/families in their books.
 
 Many people on the [Talkchess.com](http://talkchess.com/forum3/index.php)
 forum have provided insights and assistance that greatly helped in the
-development of this chess engine. Using their experience and information, I
-was able to either avoid many bugs, wrong implementations, or to improve
-existing code to work better, faster or cleaner. Thanks to all of these
-people. Below is a list of people who I particularly remember for one or
-more contributions (in no particular order).
+development of this chess engine. Using their experience and information
+that has collected there over the years (and was posted as replies to my
+questions), I was able to either avoid many bugs, wrong implementations, or
+to improve existing code to work better, faster or cleaner. Thanks to all
+of these people. Below is a list of people who I particularly remember for
+one or more contributions (in no particular order).
 
-* Richard Allbert (better known as BlueFever Software, author of VICE):
+1. Richard Allbert (better known as BlueFever Software, author of VICE):
   his "Programming a Chess Engine in C" (or the Javascript version) series
   are legendary in the chess programming community. Richard may have
   instructed an entirely new generation of chess programmers.
-* Terje Kirstihagen (author of Weiss): for the friendly Perft speed
+2. Terje Kirstihagen (author of Weiss): for the friendly Perft speed
   competition between an early version of Rustic and Weiss, to optimize
   make(), unmake(), and the move generator speed. And for his encouragement
   to keep going, by posting in my "Progress on Rustic" topic.
-* Fabian von der Warth (author of FabChess): for giving helpful information
+3. Fabian von der Warth (author of FabChess): for giving helpful information
   about the Rust programming language, which were very useful in speeding
   up the early versions of the engine.
-* H.G. Müller (author of FairyMax, MicroMax, and others): especially for
+4. H.G. Müller (author of FairyMax, MicroMax, and others): especially for
   pointing out some improvements with regard to hash table usage, and
   general assistance by patiently answering questions he must have seen
   countless times over the years.
-* Maksim Korzh (author of Wukong and BBC): for writing a great video series
+5. Maksim Korzh (author of Wukong and BBC): for writing a great video series
   in the same vein as the one written by Richard Allbert. While the series
   covers known ground, the perspective can be just from a different enough
   angle to make something 'click'.
-* Rasmus Althoff (author of CT800): for assisting in optimizing Rustic's
+6. Rasmus Althoff (author of CT800): for assisting in optimizing Rustic's
   position repetition detection, and getting rid of some unneeded stuff in
   the alpha-beta and QSearch functions.
-* Martin Sedlák (author of Cheng): I remember he answered a few questions I
+7. Martin Sedlák (author of Cheng): I remember he answered a few questions I
   had, but I can't remeber which ones... sorry.
-* Ronald de Man (author of the Syzygy tablebases, CFish and RustFish): for
+8. Ronald de Man (author of the Syzygy tablebases, CFish and RustFish): for
   helping to untangle the mess within my head regarding Principal Variation
   Search.
-* Taimo ("unserializable"): for pointing out a potential variable underflow
+9. Taimo (author of Monchester): for pointing out a potential variable underflow
   problem within the time management, that made Rustic crash in debug-mode.
-* Ed Schröder (author of Rebel and Gideon) and Robert Hyatt (author of Cray
+10. Sven Schüle (author of Jumbo, KnockOut, Surprise) for pointing out some lines of
+  redundant, and thus confusing code in Rustic's search and qsearch functions.
+11. Ed Schröder (author of Rebel and Gideon) and Robert Hyatt (author of Cray
   Blitz and Crafty): for still hanging around chess forums, answering
   questions, even after writing chess engines for 40 or 50 years.
 
 I always wanted to be "one of them": the programmers who could write chess
-programs. I have always wanted to have my own chess engine, but there was
-always "something" that got in the way of actually writing it.
-
-Now it's done: even though it is not very strong yet, I wrote my own chess
-engine from scratch. It was a long process and lots of work, but thanks to
-the help of the chess programming community, it went relatively smoothly.
-Thanks guys.
+engines. I have always wanted to have my own, but there was always
+"something" that got in the way of actually writing it. Now it's done: even
+though it is not very strong yet, I wrote my own chess engine from scratch.
+It was a long process and lots of work, but thanks to the help of the chess
+programming community, it went relatively smoothly. Thanks guys.
 

--- a/src/board/fen.rs
+++ b/src/board/fen.rs
@@ -193,7 +193,7 @@ fn castling(board: &mut Board, part: &str) -> bool {
 
     // There should be 1 to 4 castling rights. If no player has castling
     // rights, the character is '-'.
-    if length >= 1 && length <= 4 {
+    if (1..=4).contains(&length) {
         // Accepts "-" for no castling rights in addition to leaving out letters.
         for c in part.chars() {
             if CASTLING_RIGHTS.contains(c) {

--- a/src/search/alpha_beta.rs
+++ b/src/search/alpha_beta.rs
@@ -79,9 +79,6 @@ impl Search {
 
         /*=== Actual searching starts here ===*/
 
-        // Temporary variables.
-        let mut best_move = Move::new(0);
-
         // Generate the moves in this position
         let mut legal_moves_found = 0;
         let mut move_list = MoveList::new();
@@ -174,10 +171,10 @@ impl Search {
             if eval_score > alpha {
                 // Save our better evaluation score.
                 alpha = eval_score;
-                best_move = current_move;
 
+                // Update the Principal Variation.
                 pv.clear();
-                pv.push(best_move);
+                pv.push(current_move);
                 pv.append(&mut node_pv);
             }
         }
@@ -194,10 +191,6 @@ impl Search {
                 return STALEMATE;
             }
         }
-
-        // We store our best move and best PV.
-        refs.search_info.best_move = best_move;
-        refs.search_info.pv = pv.clone();
 
         // We have traversed the entire move list and found the best
         // possible move/eval_score for us at this depth. We can't improve

--- a/src/search/defs.rs
+++ b/src/search/defs.rs
@@ -98,6 +98,10 @@ impl SearchParams {
             quiet: false,
         }
     }
+
+    pub fn is_game_time(&self) -> bool {
+        self.search_mode == SearchMode::GameTime
+    }
 }
 
 // The search function will put all findings collected during the running
@@ -144,6 +148,10 @@ impl SearchInfo {
         } else {
             0
         }
+    }
+
+    pub fn interrupted(&self) -> bool {
+        self.terminate != SearchTerminate::Nothing
     }
 }
 

--- a/src/search/defs.rs
+++ b/src/search/defs.rs
@@ -111,9 +111,7 @@ pub struct SearchInfo {
     start_time: Option<Instant>,    // Time the search started
     pub depth: u8,                  // Depth currently being searched
     pub seldepth: u8,               // Maximum selective depth reached
-    pub best_move: Move,            // Best move found
     pub nodes: usize,               // Nodes searched
-    pub pv: Vec<Move>,              // Current principal variation
     pub ply: u8,                    // Number of plys from the root
     pub last_stats_sent: u128,      // When last stats update was sent
     pub last_curr_move_sent: u128,  // When last current move was sent
@@ -127,9 +125,7 @@ impl SearchInfo {
             start_time: None,
             depth: 0,
             seldepth: 0,
-            best_move: Move::new(0),
             nodes: 0,
-            pv: Vec::new(),
             ply: 0,
             last_stats_sent: 0,
             last_curr_move_sent: 0,

--- a/src/search/iter_deep.rs
+++ b/src/search/iter_deep.rs
@@ -72,7 +72,7 @@ impl Search {
             // Create summary if search was not interrupted.
             if !refs.search_info.interrupted() {
                 // Save the best move until now.
-                best_move = refs.search_info.best_move;
+                best_move = root_pv[0];
 
                 // Create search summary for this depth.
                 let elapsed = refs.search_info.timer_elapsed();
@@ -85,7 +85,7 @@ impl Search {
                     mate: 0,
                     nodes,
                     nps: Search::nodes_per_second(nodes, elapsed),
-                    pv: refs.search_info.pv.clone(),
+                    pv: root_pv.clone(),
                 };
 
                 // Create information for the engine

--- a/src/search/iter_deep.rs
+++ b/src/search/iter_deep.rs
@@ -33,7 +33,7 @@ impl Search {
         // Working variables
         let mut depth = 1;
         let mut best_move = Move::new(0);
-        let mut temp_pv: Vec<Move> = Vec::new();
+        let mut root_pv: Vec<Move> = Vec::new();
         let mut stop = false;
         let is_game_time = refs.search_params.is_game_time();
 
@@ -67,7 +67,7 @@ impl Search {
             refs.search_info.depth = depth;
 
             // Get the evaluation for this depth.
-            let eval = Search::alpha_beta(depth, -INF, INF, &mut temp_pv, refs);
+            let eval = Search::alpha_beta(depth, -INF, INF, &mut root_pv, refs);
 
             // Create summary if search was not interrupted.
             if !refs.search_info.interrupted() {

--- a/src/search/iter_deep.rs
+++ b/src/search/iter_deep.rs
@@ -22,7 +22,7 @@ with this program.  If not, see <http://www.gnu.org/licenses/>.
 ======================================================================= */
 
 use super::{
-    defs::{SearchMode, SearchRefs, SearchResult, SearchTerminate, INF},
+    defs::{SearchMode, SearchRefs, SearchResult, INF},
     ErrFatal, Information, Search, SearchReport, SearchSummary,
 };
 use crate::{defs::MAX_DEPTH, movegen::defs::Move};
@@ -35,7 +35,7 @@ impl Search {
         let mut best_move = Move::new(0);
         let mut temp_pv: Vec<Move> = Vec::new();
         let mut stop = false;
-        let is_game_time = refs.search_params.search_mode == SearchMode::GameTime;
+        let is_game_time = refs.search_params.is_game_time();
 
         // Determine available time in case of GameTime search mode.
         if is_game_time {
@@ -70,8 +70,7 @@ impl Search {
             let eval = Search::alpha_beta(depth, -INF, INF, &mut temp_pv, refs);
 
             // Create summary if search was not interrupted.
-            let interrupted = refs.search_info.terminate != SearchTerminate::Nothing;
-            if !interrupted {
+            if !refs.search_info.interrupted() {
                 // Save the best move until now.
                 best_move = refs.search_info.best_move;
 
@@ -107,7 +106,7 @@ impl Search {
 
             // Stop deepening the search if the current depth was
             // interrupted, or if the time is up.
-            stop = interrupted || time_up;
+            stop = refs.search_info.interrupted() || time_up;
         }
 
         // Search is done. Report best move and reason to terminate.

--- a/src/search/qsearch.rs
+++ b/src/search/qsearch.rs
@@ -67,9 +67,6 @@ impl Search {
         // the recursion, or until there are no more captures available.
         // Then the function will return after looping the move list.
 
-        // Temporary variables.
-        let mut best_move = Move::new(0);
-
         // Generate only capture moves.
         let mut move_list = MoveList::new();
         let mtc = MoveType::Capture;
@@ -138,16 +135,13 @@ impl Search {
             if eval_score > alpha {
                 // Save our better evaluation score.
                 alpha = eval_score;
-                best_move = current_move;
+
+                // Update the Principal Variation.
                 pv.clear();
-                pv.push(best_move);
+                pv.push(current_move);
                 pv.append(&mut node_pv);
             }
         }
-
-        // Store the best move and best PV we found.
-        refs.search_info.best_move = best_move;
-        refs.search_info.pv = pv.clone();
 
         // We have traversed the entire move list and found the best score for us,
         // so we return this.


### PR DESCRIPTION
Remove some redundant code from alpha_beta() and quiescence(). Adapt iterative_deepening() to read from root_pv (formerly called temp_pv). Remove the now redundant best_move and pv variables from search_info.