### PR TITLE
Fix extra module does not compile

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -162,7 +162,7 @@ dependencies = [
 
 [[package]]
 name = "rustic-alpha"
-version = "3.0.0"
+version = "3.0.1"
 dependencies = [
  "clap",
  "crossbeam-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "rustic-alpha"
-version = "3.0.0"
+version = "3.0.1"
 authors = ["Marcel Vanthoor"]
 edition = "2018"
 

--- a/src/board.rs
+++ b/src/board.rs
@@ -189,11 +189,11 @@ impl Board {
         self.piece_list = self.init_piece_list();
         self.game_state.zobrist_key = self.init_zobrist_key();
 
-        let material = material::count(&self);
+        let material = material::count(self);
         self.game_state.material[Sides::WHITE] = material.0;
         self.game_state.material[Sides::BLACK] = material.1;
 
-        let psqt = psqt::apply(&self);
+        let psqt = psqt::apply(self);
         self.game_state.psqt[Sides::WHITE] = psqt.0;
         self.game_state.psqt[Sides::BLACK] = psqt.1;
     }

--- a/src/board/playmove.rs
+++ b/src/board/playmove.rs
@@ -158,7 +158,7 @@ impl Board {
 
         // When running in debug mode, check the incrementally updated
         // values such as Zobrist key and meterial count.
-        debug_assert!(check_incrementals(&self));
+        debug_assert!(check_incrementals(self));
 
         // Report if the move was legal or not.
         is_legal

--- a/src/extra/testsuite.rs
+++ b/src/extra/testsuite.rs
@@ -91,7 +91,7 @@ pub fn run(tt: Arc<Mutex<TT<PerftData>>>, tt_enabled: bool) {
                 .map(|s| s.to_string())
                 .collect();
 
-            let depth = (depth_ln[0][1..]).parse::<u8>().unwrap_or(0);
+            let depth = (depth_ln[0][1..]).parse::<u8>().unwrap_or(0) as i8;
             let expected_ln = depth_ln[1].parse::<u64>().unwrap_or(0);
 
             // Abort if depth or expected leaf node parsing fails.

--- a/src/extra/wizardry.rs
+++ b/src/extra/wizardry.rs
@@ -137,7 +137,7 @@ pub fn find_magics(piece: Piece) {
     let expected = if is_rook { r_ts } else { b_ts };
     const ERROR: &str = "Creating magics failed. Permutations were skipped.";
 
-    assert!(offset == expected, ERROR);
+    assert!(offset == expected, "{}", ERROR);
 }
 
 // Print the magic number.


### PR DESCRIPTION
The "extra" module didn't compile because of a variable having the wrong type.